### PR TITLE
Node has embedded icon

### DIFF
--- a/lib/thetamind/read_model/node_model.ex
+++ b/lib/thetamind/read_model/node_model.ex
@@ -1,11 +1,13 @@
 defmodule Thetamind.ReadModel.NodeModel do
   use Ecto.Schema
+  alias __MODULE__
 
   import Ecto.Changeset
 
   @primary_key {:id, :binary_id, autogenerate: false}
   schema "nodes" do
     field :name, :string
+    embeds_one :icon, NodeModel.Icon, on_replace: :update
 
     timestamps()
   end
@@ -13,6 +15,22 @@ defmodule Thetamind.ReadModel.NodeModel do
   def changeset(node \\ %__MODULE__{}, attrs) do
     node
     |> cast(attrs, [:id, :name])
+    |> cast_embed(:icon, with: &icon_changeset/2)
     |> validate_required([:id, :name])
+  end
+
+  def icon_changeset(icon, attrs \\ %{}) do
+    icon
+    |> cast(attrs, [:key, :value])
+    |> validate_required([:key, :value])
+  end
+
+  defmodule Icon do
+    use Ecto.Schema
+
+    embedded_schema do
+      field(:key, Ecto.Enum, values: [:emoji, :image])
+      field(:value, :string)
+    end
   end
 end

--- a/lib/thetamind/tasks/protocol/create_node.ex
+++ b/lib/thetamind/tasks/protocol/create_node.ex
@@ -8,6 +8,7 @@ defmodule Thetamind.Tasks.Protocol.CreateNode do
 
   field :name, :string
   field :pet_type, PetFields.pet_type(), required: false
+  field :icon, :map, required: false
 
   # Change this as needed for your needs. See authorize_command/2 in support/blunt/dispatch_strategy/command_strategy
   metadata :auth,

--- a/lib/thetamind_web/schema/task_types.ex
+++ b/lib/thetamind_web/schema/task_types.ex
@@ -13,6 +13,12 @@ defmodule ThetamindWeb.Schema.TaskTypes do
   object :task do
     field :id, :id
     field :name, :string
+    field :icon, :icon
+  end
+
+  object :icon do
+    field :key, :string
+    field :value, :string
   end
 
   define_connection(:task, total_count: true)
@@ -20,9 +26,44 @@ defmodule ThetamindWeb.Schema.TaskTypes do
   object :task_queries do
     derive_query Queries.GetNode, :task
     derive_connection Queries.ListNodes, :task, []
+
+    field :get_node_with_icon, :task do
+      arg :id, :id
+
+      resolve(fn _, %{id: id}, _ ->
+        alias Thetamind.ReadModel.NodeModel
+
+        Thetamind.Repo.get(NodeModel, id)
+      end)
+    end
   end
 
   object :task_mutations do
-    derive_mutation Protocol.CreateNode, :task, arg_types: [pet_type: :pet_type]
+    derive_mutation Protocol.CreateNode, :task, except: [:icon], arg_types: [pet_type: :pet_type, icon: :icon_input]
+
+    # derive_mutation Protocol.CreateNode, :task,
+    #   as: :create_node_with_icon,
+    #   except: [:pet_type],
+    #   arg_types: [pet_type: :pet_type, icon: :icon_input]
+
+    field :create_node_with_icon, :task do
+      arg :name, non_null(:string)
+      arg :icon, :icon_input
+
+      resolve(fn _, args, _ ->
+        {:ok, command} = Thetamind.Tasks.Protocol.CreateNode.new(args)
+
+        with {:ok, aggregate} <-
+               Thetamind.CommandedApp.dispatch(command, returning: :aggregate_state, consistency: :strong) do
+          node = Thetamind.Repo.get(Thetamind.ReadModel.NodeModel, aggregate.id)
+          {:ok, node}
+        end
+      end)
+    end
+  end
+
+  input_object :icon_input do
+    field :key, :string
+    field :value, :string
   end
 end

--- a/priv/repo/migrations/20220805221350_initial.exs
+++ b/priv/repo/migrations/20220805221350_initial.exs
@@ -4,6 +4,7 @@ defmodule Thetamind.Repo.Migrations.Initial do
   def change do
     create table(:nodes) do
       add :name, :string
+      add :icon, :map
       timestamps()
     end
   end

--- a/test/thetamind_web/schema/embedded_map_test.exs
+++ b/test/thetamind_web/schema/embedded_map_test.exs
@@ -1,0 +1,31 @@
+defmodule ThetamindWeb.Schema.EmbeddedMapTest do
+  use ThetamindWeb.ConnCase
+
+  describe "createNodeWithIcon" do
+    @query """
+      mutation createNodeWithIcon($name: String!, $icon: IconInput!){
+        createNodeWithIcon(name: $name, icon: $icon){
+          id
+          name
+          icon {
+            key
+            value
+          }
+        }
+      }
+    """
+
+    test "happy path", %{conn: conn} do
+      name = Faker.Commerce.department()
+      vars = %{name: name, icon: %{key: "emoji", value: "😂"}}
+
+      assert %{"createNodeWithIcon" => %{"id" => id, "name" => ^name, "icon" => %{"key" => "emoji", "value" => "😂"}}} =
+               conn
+               |> post("/api", %{query: @query, variables: vars})
+               |> json_response(200)
+               |> get_in(["data"])
+
+      assert {:ok, _} = UUID.info(id)
+    end
+  end
+end


### PR DESCRIPTION
@trbngr Is there a simple way of using `derive_mutation` from a command with a map/embeds_one? I'm unsure how to set up a `Blunt.Message.Schema.FieldDefinition` and configuring `arg_types` mapping. 

I've set up a manual Absinthe/Ecto example. When I convert to `derive_mutation` in my own project and define a `FieldDefinition` provider I get error missing function `handle_validate/2` on the field definition without guidance to why my module is missing that behaviour. But I see no such method on your `PetFields` example. 

Could you provide insight? 

What I've read:
https://appunite.com/blog/why-you-shouldn-t-use-map-fields-in-schemas-with-absinthe